### PR TITLE
Update auth to omit content-type headers and body

### DIFF
--- a/csp_adapter_symphony/adapter_config.py
+++ b/csp_adapter_symphony/adapter_config.py
@@ -161,9 +161,6 @@ class SymphonyRoomMapper:
 
 
 def _client_cert_post(host: str, request_url: str, cert_file: str, key_file: str) -> str:
-    request_headers = {"Content-Type": "application/json"}
-    request_body_dict = {}
-
     # Define the client certificate settings for https connection
     context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
     context.load_cert_chain(certfile=cert_file, keyfile=key_file)
@@ -172,7 +169,9 @@ def _client_cert_post(host: str, request_url: str, cert_file: str, key_file: str
     connection = http.client.HTTPSConnection(host, port=443, context=context)
 
     # Use connection to submit a HTTP POST request
-    connection.request(method="POST", url=request_url, headers=request_headers, body=json.dumps(request_body_dict))
+    # Note that we omit content-type headers and the request body per Symphony's docs here:
+    # https://rest-api.symphony.com/main/bot-authentication/session-authenticate
+    connection.request(method="POST", url=request_url, headers={})
 
     # Print the HTTP response from the IOT service endpoint
     response = connection.getresponse()

--- a/docs/wiki/Build-from-Source.md
+++ b/docs/wiki/Build-from-Source.md
@@ -61,11 +61,11 @@ make build
 
 `csp-adapter-symphony` has linting and auto formatting.
 
-| Language | Linter      | Autoformatter | Description |
+| Language | Linter | Autoformatter | Description |
 | :------- | :---- ----- | :------------ | :---------- |
-| Python   | `ruff`      | `ruff`        | Style       |
-| Markdown | `mdformat`  | `mdformat`    | Style       |
-| Markdown | `codespell` |               | Spelling    |
+| Python | `ruff` | `ruff` | Style |
+| Markdown | `mdformat` | `mdformat` | Style |
+| Markdown | `codespell` | | Spelling |
 
 **Python Linting**
 

--- a/docs/wiki/Contribute.md
+++ b/docs/wiki/Contribute.md
@@ -1,6 +1,6 @@
 Contributions are welcome on this project. We distribute under the terms of the [Apache 2.0 license](https://github.com/Point72/csp-adapter-symphony/blob/main/LICENSE).
 
-> \[!NOTE\] > `csp-adapter-symphony` requires [Developer Certificate of Origin](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) for all contributions.
+> [!NOTE] > `csp-adapter-symphony` requires [Developer Certificate of Origin](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) for all contributions.
 > This is enforced by a [Probot GitHub App](https://probot.github.io/apps/dco/), which checks that commits are "signed".
 > Read [instructions to configure commit signing](Local-Development-Setup#configure-commit-signing).
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -7,7 +7,7 @@ A [csp](https://github.com/point72/csp) adapter for [symphony](https://symphony.
 - [Learn more about csp](https://github.com/Point72/csp)
 - [Install csp-adapter-symphony](Installation) and [get started](First-Steps)
 
-> \[!TIP\]
+> [!TIP]
 > Find relevant docs with GitHub’s search function, use `repo:Point72/csp-adapter-symphony type:wiki <search terms>` to search the documentation Wiki Pages.
 
 ## Community


### PR DESCRIPTION
**Describe the bug**
Symphony recently made a release that changed how an invalid request is handled. This causes issues with session creation.

**To Reproduce**
Sending empty body to POST /sessionauth/v1/authenticate results in either a 401 response (if a content-type header is sent) or a 500 response (if no header is sent).

E.g., the following results in a 401 response:
```python
def _client_cert_post(host: str, request_url: str, cert_file: str, key_file: str) -> str:
    request_headers = {"Content-Type": "application/json"}

    context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
    context.load_cert_chain(certfile=cert_file, keyfile=key_file)
    connection = http.client.HTTPSConnection(host, port=443, context=context)
    connection.request(
        method="POST",
        url=request_url,
        headers=request_headers,
        body=json.dumps({}),
    )
    response = connection.getresponse()

    if response.status != 200:
        print(response.read().decode("utf-8"))
        raise Exception(
            f"Cannot connect for symphony handshake to https:{host}{request_url}: {response.status}:{response.reason}"
        )
    data = response.read().decode("utf-8")

    return json.loads(data)
```

**Expected Behavior**
We expect tokens to be returned as in https://rest-api.symphony.com/main/bot-authentication/session-authenticate

**Error Message**
401 or 500 response from Symphony

**Runtime Environment**
CSP: 0.0.5
SYS: 3.11.9 | packaged by conda-forge | (main, Apr 19 2024, 18:36:13) [GCC 12.3.0]
SYS platform: Linux

**Additional context**
Without authentication tokens, this adapter becomes unusable with certificate and key.