### PR TITLE
Tweak markdown table in docs to not confuse linter

### DIFF
--- a/docs/wiki/Build-from-Source.md
+++ b/docs/wiki/Build-from-Source.md
@@ -61,11 +61,11 @@ make build
 
 `csp-adapter-symphony` has linting and auto formatting.
 
-| Language | Linter | Autoformatter | Description |
-| :------- | :---- ----- | :------------ | :---------- |
-| Python | `ruff` | `ruff` | Style |
-| Markdown | `mdformat` | `mdformat` | Style |
-| Markdown | `codespell` | | Spelling |
+| Language | Linter      | Autoformatter | Description |
+| :------- | :---------- | :------------ | :---------- |
+| Python   | `ruff`      | `ruff`        | Style       |
+| Markdown | `mdformat`  | `mdformat`    | Style       |
+| Markdown | `codespell` |               | Spelling    |
 
 **Python Linting**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,8 @@ develop = [
     "check-manifest",
     "codespell>=2.3,<2.4",
     "hatchling",
-    "mdformat>=0.7.18,<0.8",
+    "mdformat>=0.7.19,<0.8",
+    "mdformat-tables>=1,<1.1",
     "ruff>=0.6,<0.8",
     "twine>=5,<6",
     # test


### PR DESCRIPTION
looks like `mdformat` is a little flaky around certain markdown tables