### PR TITLE
Remove unnecessary indents when sending messages

### DIFF
--- a/csp_adapter_symphony/adapter.py
+++ b/csp_adapter_symphony/adapter.py
@@ -52,13 +52,7 @@ class Presence(csp.Enum):
 
 def send_symphony_message(msg: str, room_id: str, message_create_url: str, header: Dict[str, str]):
     """Wrap message string and send it to symphony"""
-    out_json = {
-        "message": f"""
-        <messageML>
-        {msg}
-        </messageML>
-        """
-    }
+    out_json = {"message": f"<messageML>{msg}</messageML>"}
     url = message_create_url.format(sid=room_id)
     return requests.post(
         url=url,

--- a/csp_adapter_symphony/tests/test_adapter.py
+++ b/csp_adapter_symphony/tests/test_adapter.py
@@ -147,7 +147,7 @@ class TestSymphony:
         assert requests_mock.call_args_list == [
             call(
                 url="message/create/url",
-                json={"message": "\n        <messageML>\n        test_msg\n        </messageML>\n        "},
+                json={"message": "<messageML>test_msg</messageML>"},
                 headers={"Authorization": "Bearer Blerg"},
             )
         ]
@@ -468,7 +468,7 @@ class TestSymphony:
             assert (
                 call(
                     url="https://symphony.host/agent/v4/stream/{sid}/message/create",
-                    json={"message": "\n        <messageML>\n        Hello <@sender-user-id>!\n        </messageML>\n        "},
+                    json={"message": "<messageML>Hello <@sender-user-id>!</messageML>"},
                     headers={
                         "sessionToken": "a-fake-token",
                         "keyManagerToken": "a-fake-token",
@@ -514,7 +514,7 @@ class TestSymphony:
                 assert (
                     call(
                         url="https://symphony.host/agent/v4/stream/{sid}/message/create",
-                        json={"message": "\n        <messageML>\n        ERROR: Could not send messsage on Symphony\n        </messageML>\n        "},
+                        json={"message": "<messageML>ERROR: Could not send messsage on Symphony</messageML>"},
                         headers={
                             "sessionToken": "a-fake-token",
                             "keyManagerToken": "a-fake-token",
@@ -527,7 +527,7 @@ class TestSymphony:
                 assert (
                     call(
                         url="https://symphony.host/agent/v4/stream/{sid}/message/create",
-                        json={"message": "\n        <messageML>\n        Hello!\n        </messageML>\n        "},
+                        json={"message": "<messageML>Hello!</messageML>"},
                         headers={
                             "sessionToken": "a-fake-token",
                             "keyManagerToken": "a-fake-token",


### PR DESCRIPTION
This PR fixes a bug in `send_symphony_message` function where extra whitespaces are added at the start and end of messages. This issue isn't visible on the desktop or browser versions of the Symphony app, but it shows up on the mobile app.