### PR TITLE
Allow users to specify custom datafeed IDs

### DIFF
--- a/csp_adapter_symphony/adapter_config.py
+++ b/csp_adapter_symphony/adapter_config.py
@@ -55,6 +55,9 @@ class SymphonyAdapterConfig(BaseModel):
     initial_interval_ms: int = Field(500, description="Initial interval to wait between attempts, in milliseconds")
     multiplier: float = Field(2.0, description="Multiplier between attempt delays for exponential backoff")
     max_interval_ms: int = Field(300000, description="Maximum delay between retry attempts, in milliseconds")
+    datafeed_id: str = Field(
+        "", description="The ID of the datafeed to be used by the datafeed reader. If left empty, a datafeed ID will be automatically assigned"
+    )
 
     _default_endpoints = {
         "message_create_url": "/agent/v4/stream/{sid}/message/create",

--- a/csp_adapter_symphony/tests/test_adapter.py
+++ b/csp_adapter_symphony/tests/test_adapter.py
@@ -281,7 +281,7 @@ class TestSymphony:
             named_temporary_file_mock.return_value.__enter__.return_value.name = "a_temp_file"
 
             # mock get request response based on url
-            def get_request(url, headers, json=None):
+            def get_request(url, headers, params=None):
                 assert url in ("https://symphony.host/pod/v3/room/{room_id}/info", "https://symphony.host/agent/v5/datafeeds")
                 resp_mock = MagicMock()
                 resp_mock.status_code = 200
@@ -406,6 +406,7 @@ class TestSymphony:
                         "keyManagerToken": "a-fake-token",
                         "Accept": "application/json",
                     },
+                    params=None,
                 ),
                 call(
                     "https://symphony.host/pod/v3/room/{room_id}/info",
@@ -438,6 +439,7 @@ class TestSymphony:
                             "keyManagerToken": "a-fake-token",
                             "Accept": "application/json",
                         },
+                        json=None,
                     )
                     in requests_post_mock.call_args_list
                 )


### PR DESCRIPTION
Currently, the `SymphonyAdapter` tries to use the same datafeed if one is present. The problem arises when a user wants to launch multiple instances of the same bot at the same time. In such cases, the incoming messages aren't streamed to each of these instances, just to one of them, even though Symphony allows using multiple datafeeds (up to 20 per user, [ref](https://rest-api.symphony.com/main/datafeed/create-datafeed-v5))

This PR allows passing a `datafeed_id` to the `SymphonyAdapterConfig`. This ID is then used when creating and reading from the datafeed, preventing multiple instances from stealing messages from one another. If the user doesn't provide an ID, the default behavior remains unchanged, and the ID is assigned by the Symphony server as it is now.